### PR TITLE
 docs: Add PHP Data Types Guide

### DIFF
--- a/basic/data-type.php
+++ b/basic/data-type.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ *
+ * 
+ **  PHP supports various data types to represent different kinds of values. Here are the primary data types in PHP:
+ *  
+ *    1. **Integer:**
+ *       - Whole numbers without decimal points.
+ *       - Example: `$count = 10;`
+ *    
+ *    2. **Float (Floating-Point or Double):**
+ *       - Numbers with decimal points or in exponential form.
+ *       - Example: `$price = 19.99;`
+ *    
+ *    3. **String:**
+ *       - A sequence of characters enclosed in single or double quotes.
+ *       - Example: `$message = "Hello, PHP!";`
+ *    
+ *    4. **Boolean:**
+ *       - Represents true or false.
+ *       - Example: `$is_active = true;`
+ *    
+ *    5. **Array:**
+ *       - An ordered or unordered collection of elements.
+ *       - Example: `$colors = array("red", "green", "blue");`
+ *    
+ *    6. **Object:**
+ *       - Instances of user-defined classes.
+ *       - Example: `$car = new Car();`
+ *    
+ *    7. **Resource:**
+ *       - Special variables holding references to external resources (e.g., database connections).
+ *       - Example: `$file = fopen("example.txt", "r");`
+ *    
+ *    8. **NULL:**
+ *       - Represents a variable with no value.
+ *       - Example: `$noValue = null;`
+ *    
+ *    9. **Resource:**
+ *       - A special type used to store and manipulate dates and times.
+ *       - Example: `$currentDate = new DateTime();`
+ *    
+ *    PHP is a loosely typed language, meaning you don't need to declare the data type explicitly when declaring a variable. The interpreter *    determines the data type based on the context. For example:
+ *    
+ *    
+ *    $number = 42;       // Integer
+ *    $pi = 3.14;         // Float
+ *    $name = "John";     // String
+ *    $is_valid = true;   // Boolean
+ *  
+ * 
+ * 
+ */
+
+
+
+
+
+
+?>


### PR DESCRIPTION
docs: Add PHP Data Types Guide

In this pull request, we've added comprehensive documentation covering PHP data types. The guide includes explanations and examples for integers, floats, strings, booleans, arrays, objects, resources, NULL, and DateTime. This information aims to provide clarity on how to work with different data types in PHP, aiding both beginners and experienced developers. 

Please review and merge these changes to enhance the documentation for our community.

Closes #2 

#documentation #php #datatypes
