### PR TITLE
Fix namespace autoloading issue for class 'App\User'

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@ Website: http://www.yourwebsite.com
 */
 $title = "PHP Forms";
 // Header includes templates
-include_once("./inc/header.php");
+include_once ("./inc/header.php");
 
 $title = "php-playground";
 $startDate = 2024;
@@ -46,7 +46,8 @@ $startDate = 2024;
         // include './form/get.php';
         // include './form/post.php';
         //include './function/function.php';
-        include_once './superglobal/superglobal.php';
+        // include_once './superglobal/superglobal.php';
+        include './namespace/index.php';
         ?>
     </div>
 </main>

--- a/namespace/User.php
+++ b/namespace/User.php
@@ -1,0 +1,22 @@
+<?php
+/// Define your User class in the 'App' namespace
+namespace App;
+
+class User
+{
+    public function login()
+    {
+        // Login logic here
+        echo "Welcome to login function!";
+    }
+
+    public function register($username, $password, $email)
+    {
+        // Registration logic here
+    }
+
+    public function updateProfile($userId, $newData)
+    {
+        // Profile update logic here
+    }
+}

--- a/namespace/index.php
+++ b/namespace/index.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Namespace: MyNamespace
+ *
+ * Description: This namespace contains classes and functions related to a specific functionality.
+ *
+ * Author: Pradip Chaudhary
+ * Author URI: https://pradipchaudhary.com.np/
+ * Version: 1.0.0
+ */
+
+
+// Your code goes here...
+
+
+// Import the necessary namespaces
+
+
+$user = new \App\User();
+
+// Use the User class methods
+echo $user->login();


### PR DESCRIPTION
Fix namespace autoloading issue for class "App\User"

The namespace autoloading was not correctly set up, resulting in a fatal error when attempting to instantiate the "App\User" class. This commit resolves the issue by ensuring proper namespace declaration and autoloading configuration.

Bug: Fatal error: Uncaught Error: Class "App\User" not found in C:\xampp\htdocs\php-playground\namespace\index.php:20 Stack trace: #0 C:\xampp\htdocs\php-playground\index.php(50): include() #1 {main} thrown in C:\xampp\htdocs\php-playground\namespace\index.php on line 20
